### PR TITLE
Allow isTuple to work in name-mangled environments

### DIFF
--- a/src/lib/data/tuple.js
+++ b/src/lib/data/tuple.js
@@ -67,7 +67,7 @@ export class Tuple {
 
 
 export function isTuple(object) {
-    return object && object.constructor && object.constructor.name === 'Tuple';
+    return object instanceof Tuple;
 }
 
 export function tuple(array){


### PR DESCRIPTION
If you perform a production build in webpack this function fails because Tuple can get renamed to something else but Webpack and/or Terser will (correctly) not touch the string value.

This fix allows Masala to work in a minified, mangled build.