### PR TITLE
164 lines

### DIFF
--- a/masala-parser.d.ts
+++ b/masala-parser.d.ts
@@ -314,6 +314,11 @@ export interface Response<T> {
      * [[offset]] for low level parsers.
      */
     location(): number;
+
+    /**
+     * Current line of the response
+     */
+    line(): number;
 }
 
 /**

--- a/src/lib/parsec/parser.js
+++ b/src/lib/parsec/parser.js
@@ -109,10 +109,11 @@ export default class Parser {
                     response.accept(accept.value, accept.input, accept.offset, true):
                     response.reject(accept.input, accept.offset, accept.consumed)
             },
-                reject =>
-                    response.reject(
+                reject =>{
+                    return response.reject(
                         reject.input, reject.offset, reject.consumed
-                    ))
+                    )})
+
         );
 
     }

--- a/src/lib/parsec/response.js
+++ b/src/lib/parsec/response.js
@@ -60,15 +60,19 @@ class ParserResponse {
         return this.input.location(this.getOffset());
     }
 
-    /**
-     * fold takes a function to map the value depending on result
-     * Abstract function fold(accept, reject)
-     *
-     * flatMap is a specialization of fold
-     */
     line(){
         return this.input.lineAt(this.getOffset())
     }
+
+    /**
+     * fold, map and flatMap are abstract functions of ParserResponse implemented below
+     * fold takes a function to map the value depending on result
+     * Abstract function fold(accept, reject)
+     *
+     * map and flatMap is a specialization of fold when it's not rejected. They
+     * transform the value when parsing is good. In case
+     * of reject, map and flatMap always return 'this', leaving the value unchanged.
+     */
 }
 
 /**

--- a/src/lib/parsec/response.js
+++ b/src/lib/parsec/response.js
@@ -66,6 +66,9 @@ class ParserResponse {
      *
      * flatMap is a specialization of fold
      */
+    line(){
+        return this.input.lineAt(this.getOffset())
+    }
 }
 
 /**

--- a/src/lib/stream/bufferedstream.js
+++ b/src/lib/stream/bufferedstream.js
@@ -36,6 +36,11 @@ class BufferedStream extends Stream {
 
         return self.cache[index];
     }
+
+    lineAt(offset) {
+        return this.source.lineAt(offset)
+    }
+
 }
 
 function factory(source) {

--- a/src/lib/stream/parserstream.js
+++ b/src/lib/stream/parserstream.js
@@ -92,6 +92,10 @@ class ParserStream extends Stream {
             throw new Error();
         }
     }
+
+    lineAt(offset) {
+        return this.input.lineAt(this.offsets[offset])
+    }
 }
 
 function factory(parser, lowerStream) {

--- a/src/lib/stream/stream.js
+++ b/src/lib/stream/stream.js
@@ -11,6 +11,7 @@ import atry from '../data/try';
 /**
  * Abstract methods:
  * - unsafeGet(index)
+ * - lineAt(offset)
  */
 class Stream {
     constructor() {}
@@ -44,6 +45,8 @@ class Stream {
 
         return true;
     }
+
+    lineAt(offset){return 0}
 }
 
 export default Stream;

--- a/src/lib/stream/stream.js
+++ b/src/lib/stream/stream.js
@@ -45,8 +45,6 @@ class Stream {
 
         return true;
     }
-
-    lineAt(offset){return 0}
 }
 
 export default Stream;

--- a/src/lib/stream/stringstream.js
+++ b/src/lib/stream/stringstream.js
@@ -25,6 +25,11 @@ class StringStream extends Stream {
     unsafeGet(index) {
         return this.source.charAt(index);
     }
+
+    lineAt(offset){
+        const str= this.source.substring(0, offset+1);
+        return (str.match(/\n/g) || '').length + 1
+    }
 }
 
 function factory(source) {

--- a/src/lib/stream/stringstream.js
+++ b/src/lib/stream/stringstream.js
@@ -28,8 +28,7 @@ class StringStream extends Stream {
 
     lineAt(offset){
         const str= this.source.substring(0, offset+1);
-        const res =  (str.match(/\n/g) || '').length + 1
-        return res;
+        return (str.match(/\n/g) || '').length + 1;
     }
 }
 

--- a/src/lib/stream/stringstream.js
+++ b/src/lib/stream/stringstream.js
@@ -28,7 +28,8 @@ class StringStream extends Stream {
 
     lineAt(offset){
         const str= this.source.substring(0, offset+1);
-        return (str.match(/\n/g) || '').length + 1
+        const res =  (str.match(/\n/g) || '').length + 1
+        return res;
     }
 }
 

--- a/src/test/index.js
+++ b/src/test/index.js
@@ -17,10 +17,10 @@ import jsonSampleTest from './standard/json/jsonsample_test';
 
 
 export {
-    parserTests,/*
+    parserTests,
     dataTests,
     streamTests,
     genlexTests,
     jsonParseTest,
-    jsonSampleTest*/
+    jsonSampleTest
 };

--- a/src/test/index.js
+++ b/src/test/index.js
@@ -17,10 +17,10 @@ import jsonSampleTest from './standard/json/jsonsample_test';
 
 
 export {
+    parserTests,/*
     dataTests,
     streamTests,
-    parserTests,
     genlexTests,
     jsonParseTest,
-    jsonSampleTest
+    jsonSampleTest*/
 };

--- a/src/test/parsec/line-test.js
+++ b/src/test/parsec/line-test.js
@@ -1,5 +1,7 @@
 import stream from '../../lib/stream/index';
 import {C,N} from '../../lib/parsec/index';
+import {GenLex} from '../../lib/genlex/genlex';
+
 
 const eol = C.char('\n')
 
@@ -7,7 +9,7 @@ export default {
     setUp: function (done) {
         done();
     },
-
+/*
     'expect line 1 is ok': function (test) {
         const string = '007';
         // tests here
@@ -54,7 +56,33 @@ export default {
         test.equal(3, response.line());
         test.equal(false, response.isAccepted());
         test.done();
-    }
+    },
+*/
+    'line test with parser stream': function (test) {
+        const string = '\n007\nab\n12';
+        // tests here
+
+            const genlex = new GenLex();
+
+            const plus = genlex.tokenize('+');
+            const minus = genlex.tokenize('-');
+
+            let grammar = plus.or(minus).rep().thenEos();
+
+            const parser = genlex.use(grammar);
+
+            let response = parser.parse(stream.ofString('\n+ + \n - --'));
+            test.ok(response.isEos(), 'input is consumed');
+            test.equal(3, response.line(), '3rd line');
+
+            response = parser.parse(stream.ofString('\n+ + \n\n+\na \n f'));
+            test.ok(!response.isEos(), 'input is consumed');
+            test.equal(5, response.line(), '5th line');
+
+
+            test.done()
+
+    },
 
 
 

--- a/src/test/parsec/line-test.js
+++ b/src/test/parsec/line-test.js
@@ -9,7 +9,7 @@ export default {
     setUp: function (done) {
         done();
     },
-/*
+
     'expect line 1 is ok': function (test) {
         const string = '007';
         // tests here
@@ -57,7 +57,7 @@ export default {
         test.equal(false, response.isAccepted());
         test.done();
     },
-*/
+
     'line test with parser stream': function (test) {
         const string = '\n007\nab\n12';
         // tests here

--- a/src/test/parsec/line-test.js
+++ b/src/test/parsec/line-test.js
@@ -1,0 +1,61 @@
+import stream from '../../lib/stream/index';
+import {C,N} from '../../lib/parsec/index';
+
+const eol = C.char('\n')
+
+export default {
+    setUp: function (done) {
+        done();
+    },
+
+    'expect line 1 is ok': function (test) {
+        const string = '007';
+        // tests here
+        const parser = N.integer();
+        const response = parser.parse(stream.ofString(string));
+
+        test.equal(1, response.line());
+        test.done();
+    },
+    'expect line 2 is ok': function (test) {
+        const string = '007\n12';
+        // tests here
+        const parser = N.integer().then(eol).then(N.integer());
+        const response = parser.parse(stream.ofString(string));
+
+        test.equal(2, response.line());
+        test.done();
+    },
+    'multiline is ok': function (test) {
+        const string = '007\n\n12';
+        // tests here
+        const parser = N.integer().then(eol).then(N.integer());
+        const response = parser.parse(stream.ofString(string));
+
+        test.equal(3, response.line());
+        test.done();
+    },
+    'not finished parser is ok': function (test) {
+        const string = '007\nab\n12';
+        // tests here
+        const parser = N.integer().then(eol).then(N.integer());
+        const response = parser.parse(stream.ofString(string));
+
+        test.equal(2, response.line());
+        test.equal(false, response.isAccepted());
+        test.done();
+    },
+    'first lines is ok and windows': function (test) {
+        const string = '\n007\nab\n12';
+        // tests here
+        const parser = eol.then(N.integer()).then(eol).then(N.integer());
+        const response = parser.parse(stream.ofString(string));
+
+        test.equal(3, response.line());
+        test.equal(false, response.isAccepted());
+        test.done();
+    }
+
+
+
+}

--- a/src/test/parsec/parser-package-test.js
+++ b/src/test/parsec/parser-package-test.js
@@ -9,6 +9,7 @@ import charsBundleTest from './chars-bundle-test';
 import numberBundleTest from './number-bundle-test';
 import fLayerTest from './f-layer-test';
 import tupleParserTest from './tuple-parser-test';
+import lineTest from './line-test';
 
 export default {
     parserChainTest,
@@ -21,5 +22,6 @@ export default {
     charsBundleTest,
     numberBundleTest,
     fLayerTest,
-    tupleParserTest
+    tupleParserTest,
+    lineTest
 }

--- a/src/test/parsec/parser-package-test.js
+++ b/src/test/parsec/parser-package-test.js
@@ -12,7 +12,7 @@ import tupleParserTest from './tuple-parser-test';
 import lineTest from './line-test';
 
 export default {
-   /* parserChainTest,
+    parserChainTest,
     parserCoreTest,
     parserCoreDefaultTest,
     parserExtensionTest,
@@ -22,6 +22,6 @@ export default {
     charsBundleTest,
     numberBundleTest,
     fLayerTest,
-    tupleParserTest,*/
+    tupleParserTest,
     lineTest
 }

--- a/src/test/parsec/parser-package-test.js
+++ b/src/test/parsec/parser-package-test.js
@@ -12,7 +12,7 @@ import tupleParserTest from './tuple-parser-test';
 import lineTest from './line-test';
 
 export default {
-    parserChainTest,
+   /* parserChainTest,
     parserCoreTest,
     parserCoreDefaultTest,
     parserExtensionTest,
@@ -22,6 +22,6 @@ export default {
     charsBundleTest,
     numberBundleTest,
     fLayerTest,
-    tupleParserTest,
+    tupleParserTest,*/
     lineTest
 }

--- a/src/test/parsec/parser_core_test.js
+++ b/src/test/parsec/parser_core_test.js
@@ -449,7 +449,7 @@ export default {
         test.equal(response.value, 'abc'); // not tuple([a]) !
         test.done();
     },
-/*
+
     'expect (eos) to be rejected without eating char': function (test) {
 
 
@@ -463,7 +463,20 @@ export default {
         test.equal(response.value, undefined); // not tuple([a]) !
         test.done();
     },
-*/
+
+    'expect (eos) to be rejected without eating char after fail': function (test) {
+
+
+        const parser = F.try(C.char('b').eos()).or(C.char('a'));
+
+        const response =  parser.parse(stream.ofString('ab'));
+
+        test.ok(response.isAccepted(), 'should  be accepted.');
+        test.equal(response.offset, 1);
+        test.equal(response.value, "a"); // not tuple([a]) !
+        test.done();
+    },
+
     'expect (thenEos) to be accepted at the end': function (test) {
         test.expect(1);
         // tests here


### PR DESCRIPTION
- Calculate current line of the response
- independently add a case for `eos()` function